### PR TITLE
Refactor GetExchageRate

### DIFF
--- a/ex00/BitcoinExchange.cpp
+++ b/ex00/BitcoinExchange.cpp
@@ -134,13 +134,6 @@ float BitcoinExchange::ParseFloat_(const std::string &str) const {
 }
 
 float BitcoinExchange::GetExchangeRate_(const std::time_t &date) const {
-  try {
-    return database_.at(date);
-  } catch (const std::exception &) {
-    BitcoinExchange::Database::const_iterator it = database_.lower_bound(date);
-    if (it != database_.end()) {
-      it--;
-    }
-    return it != database_.end() ? it->second : 0;
-  }
+  BitcoinExchange::Database::const_iterator it = database_.lower_bound(date);
+  return it != database_.end() ? it->second : 0;
 }

--- a/ex00/BitcoinExchange.hpp
+++ b/ex00/BitcoinExchange.hpp
@@ -10,10 +10,8 @@
 
 class BitcoinExchange {
 private:
-  typedef std::time_t DateSecondsSinceEpoch;
-  typedef float BitcoinPrice;
-  typedef std::map<DateSecondsSinceEpoch, BitcoinPrice> Database;
-  typedef std::pair<DateSecondsSinceEpoch, BitcoinPrice> DataRowPair;
+  typedef std::map<std::time_t, float, std::greater<std::time_t>> Database;
+  typedef std::pair<std::time_t, float> DataRowPair;
   Database database_;
   DataRowPair ParseDataRow_(const std::string &line) const;
   void ParseInputRow_(const std::string &line) const;


### PR DESCRIPTION
Store the keys in descending order and use only lower_bound to access either the exchange date or a date before